### PR TITLE
Remove dependency on the httpMethods package in favor of net/http

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -5,7 +5,6 @@ This feature is not yet implemented!
 */
 
 import (
-	//"github.com/Beanstream/beanstream-go/httpMethods"
 	"time"
 )
 
@@ -24,7 +23,7 @@ func (api BatchAPI) MakeBatchPayment(batchCriteria BatchCriteria, batchFile stri
 
 	url := api.Config.BaseUrl() + batchUrl
 	responseType := PaymentResponse{}
-	res, err := ProcessMultiPart(httpMethods.POST, url, api.Config.MerchantId, api.Config.BatchApiKey, &responseType, batchCriteria, batchFile)
+	res, err := ProcessMultiPart(http.MethodPost, url, api.Config.MerchantId, api.Config.BatchApiKey, &responseType, batchCriteria, batchFile)
 	if err != nil {
 		return nil, err
 	}

--- a/httpMethods/doc.go
+++ b/httpMethods/doc.go
@@ -1,4 +1,0 @@
-/*
-The basic PUT, POST, GET, DELETE methods that the API supports.
-*/
-package httpMethods

--- a/httpMethods/httpMethods.go
+++ b/httpMethods/httpMethods.go
@@ -1,7 +1,0 @@
-package httpMethods
-
-// http methods
-const POST = "POST"
-const PUT = "PUT"
-const DELETE = "DELETE"
-const GET = "GET"

--- a/legato.go
+++ b/legato.go
@@ -1,8 +1,6 @@
 package beanstream
 
-import (
-	"github.com/Beanstream/beanstream-go/httpMethods"
-)
+import "net/http"
 
 const url = "https://www.beanstream.com/scripts/tokenization/tokens"
 
@@ -28,7 +26,7 @@ type legatoTokenResponse struct {
 func LegatoTokenizeCard(cardNumber string, expMo string, expYr string, cvd string) (string, error) {
 	req := legatoCardRequest{cardNumber, expMo, expYr, cvd}
 	responseType := legatoTokenResponse{}
-	res, err := ProcessBody(httpMethods.POST, url, "", "", req, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, "", "", req, &responseType)
 	if err != nil {
 		return "", err
 	}

--- a/payments.go
+++ b/payments.go
@@ -2,7 +2,7 @@ package beanstream
 
 import (
 	"fmt"
-	"github.com/Beanstream/beanstream-go/httpMethods"
+	"net/http"
 	"time"
 )
 
@@ -30,7 +30,7 @@ You must supply it a PaymentRequest that is defined in this package
 func (api PaymentsAPI) MakePayment(transaction PaymentRequest) (*PaymentResponse, error) {
 	url := api.Config.BaseUrl() + paymentUrl
 	responseType := PaymentResponse{}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.PaymentsApiKey, transaction, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.PaymentsApiKey, transaction, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (api PaymentsAPI) CompletePayment(transId string, request PaymentRequest) (
 	url := api.Config.BaseUrl() + completionUrl
 	url = fmt.Sprintf(url, transId)
 	responseType := PaymentResponse{}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.PaymentsApiKey, request, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.PaymentsApiKey, request, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (api PaymentsAPI) VoidPayment(transId string, amount float32) (*PaymentResp
 	url = fmt.Sprintf(url, transId)
 	responseType := PaymentResponse{}
 	req := voidRequest{amount}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.PaymentsApiKey, req, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.PaymentsApiKey, req, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (api PaymentsAPI) ReturnPayment(transId string, amount float32) (*PaymentRe
 	url = fmt.Sprintf(url, transId)
 	responseType := PaymentResponse{}
 	req := returnRequest{amount}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.PaymentsApiKey, req, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.PaymentsApiKey, req, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (api PaymentsAPI) GetTransaction(transId string) (*Transaction, error) {
 	url = fmt.Sprintf(url, transId)
 
 	responseType := Transaction{}
-	res, err := Process(httpMethods.GET, url, api.Config.MerchantId, api.Config.PaymentsApiKey, &responseType)
+	res, err := Process(http.MethodGet, url, api.Config.MerchantId, api.Config.PaymentsApiKey, &responseType)
 	if err != nil {
 		return nil, err
 	}

--- a/profiles.go
+++ b/profiles.go
@@ -2,7 +2,7 @@ package beanstream
 
 import (
 	"fmt"
-	"github.com/Beanstream/beanstream-go/httpMethods"
+	"net/http"
 	"strings"
 	"time"
 )
@@ -27,7 +27,7 @@ type ProfilesAPI struct {
 func (api ProfilesAPI) CreateProfile(profile Profile) (*ProfileResponse, error) {
 	url := api.Config.BaseUrl() + profilesBaseUrl
 	responseType := ProfileResponse{}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.ProfilesApiKey, profile, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.ProfilesApiKey, profile, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (api ProfilesAPI) GetProfile(profileId string) (*Profile, error) {
 	url = fmt.Sprintf(url, profileId)
 
 	responseType := Profile{}
-	res, err := Process(httpMethods.GET, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
+	res, err := Process(http.MethodGet, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func (api ProfilesAPI) UpdateProfile(profile *Profile) (*ProfileResponse, error)
 	profile.Token = Token{}     // can only create a profile with a token, cannot update the token
 
 	responseType := ProfileResponse{}
-	res, err := ProcessBody(httpMethods.PUT, url, api.Config.MerchantId, api.Config.ProfilesApiKey, profile, &responseType)
+	res, err := ProcessBody(http.MethodPut, url, api.Config.MerchantId, api.Config.ProfilesApiKey, profile, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (api ProfilesAPI) DeleteProfile(profileId string) (*ProfileResponse, error)
 	url = fmt.Sprintf(url, profileId)
 
 	responseType := ProfileResponse{}
-	res, err := Process(httpMethods.DELETE, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
+	res, err := Process(http.MethodDelete, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (api ProfilesAPI) GetCards(profileId string) ([]CreditCard, error) {
 	url = fmt.Sprintf(url, profileId)
 
 	responseType := profileCardsResponse{}
-	res, err := Process(httpMethods.GET, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
+	res, err := Process(http.MethodGet, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (api ProfilesAPI) GetCard(profileId string, cardId int) (*CreditCard, error
 	url = fmt.Sprintf(url, profileId)
 
 	responseType := profileCardsResponse{}
-	res, err := Process(httpMethods.GET, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
+	res, err := Process(http.MethodGet, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (api ProfilesAPI) AddCard(profileId string, card CreditCard) (*ProfileRespo
 
 	wrapper := cardWrapper{card}
 	responseType := ProfileResponse{}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &wrapper, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &wrapper, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (api ProfilesAPI) AddTokenizedCard(profileId string, cardholderName string,
 	//card := CreditCard{Number: token}
 	wrapper := tokenWrapper{Token: t}
 	responseType := ProfileResponse{}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &wrapper, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &wrapper, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (api ProfilesAPI) DeleteCard(profileId string, cardId int) (*ProfileRespons
 	url = fmt.Sprintf(url, profileId, cardId)
 
 	responseType := ProfileResponse{}
-	res, err := Process(httpMethods.DELETE, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
+	res, err := Process(http.MethodDelete, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &responseType)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (api ProfilesAPI) UpdateCard(profileId string, card CreditCard) (*ProfileRe
 
 	wrapper := cardWrapper{card}
 	responseType := ProfileResponse{}
-	res, err := ProcessBody(httpMethods.PUT, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &wrapper, &responseType)
+	res, err := ProcessBody(http.MethodPut, url, api.Config.MerchantId, api.Config.ProfilesApiKey, &wrapper, &responseType)
 	if err != nil {
 		return nil, err
 	}

--- a/reports.go
+++ b/reports.go
@@ -2,7 +2,7 @@ package beanstream
 
 import (
 	//"fmt"
-	"github.com/Beanstream/beanstream-go/httpMethods"
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -42,7 +42,7 @@ func (api ReportsAPI) Query(startTime time.Time, endTime time.Time, startRow int
 		strconv.Itoa(endRow),
 		criteria}
 	responseType := RecordsResult{}
-	res, err := ProcessBody(httpMethods.POST, url, api.Config.MerchantId, api.Config.ReportingApiKey, &q, &responseType)
+	res, err := ProcessBody(http.MethodPost, url, api.Config.MerchantId, api.Config.ReportingApiKey, &q, &responseType)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The golang standard library [already has constants defined for http methods](https://golang.org/pkg/net/http/#pkg-constants). This makes the httpMethods package a bit redundant. This PR removes the package in favor of `http.MethodXxxx`